### PR TITLE
Solve TextInput class not found in custom navbar option page

### DIFF
--- a/app/Filament/Resources/NavBarOptionResource/Pages/CreateCustomNavBar.php
+++ b/app/Filament/Resources/NavBarOptionResource/Pages/CreateCustomNavBar.php
@@ -49,7 +49,7 @@ class CreateCustomNavBar extends Page implements HasForms, HasTable
         return [
             Forms\Components\Section::make()
                 ->schema([
-                    Forms\components\TextInput::make('name')
+                    TextInput::make('name')
                         ->required(),
                     Select::make('type')
                         ->options([


### PR DESCRIPTION
solved this problem

<img width="1919" height="957" alt="Captura de pantalla 2025-07-16 163057" src="https://github.com/user-attachments/assets/bcc3d9d2-7902-475a-a07b-6712981b5bcd" />
